### PR TITLE
Handle non existent path

### DIFF
--- a/esy-mode.el
+++ b/esy-mode.el
@@ -99,7 +99,7 @@ later be used to obtain more info about the esy project"
     (progn
       (when (not
 	     (file-directory-p parent-path))
-	(make-directory parent-path)
+	(make-directory parent-path t)
 	(message (format "esy-mode just created %s for you. If this is annoying, please raise a ticket." parent-path))
       (esy/project--of-path parent-path)))))
 

--- a/esy-mode.el
+++ b/esy-mode.el
@@ -95,7 +95,13 @@ be used to obtain more info about the project"
 (defun esy/project--of-file-path (file-path)
   "Returns an abstract structure that can
 later be used to obtain more info about the esy project"
-  (let* ((project-path (file-name-directory file-path))) (progn (esy/project--of-path project-path))))
+  (let* ((parent-path (file-name-directory file-path)))
+    (progn
+      (when (not
+	     (file-directory-p parent-path))
+	(make-directory parent-path)
+	(message (format "esy-mode just created %s for you. If this is annoying, please raise a ticket." parent-path))
+      (esy/project--of-path parent-path)))))
 
 (defun esy/project--of-buffer (buffer)
   "Returns an abstract structure that can 


### PR DESCRIPTION
Often, when creating new files, the path may not entirely be
created (until the users saves the buffers). This greats in the way of
getting diagnostics for the file.

A good (but not the most user friendly) is to create the directory
ourselves.

A better approach is to recursively climb up until an existent path is
found and then that path is passed to `esy/project--of-path`